### PR TITLE
Added Machine Readable Prereqs

### DIFF
--- a/patterns.py
+++ b/patterns.py
@@ -1,0 +1,36 @@
+import regex as re
+
+# Reusable strings
+course_code_pattern = r"[A-Z]{3,4}\s*[0-9]{4,5}[A-Za-z]{0,1}"
+not_real_course_codes = r"(?P<ForU>.*[34]U.*)|(?:an )?equivalent|Permission of the School|Permission de l'(?:École|Institut)|Approval of the instructor|Permission du Département"
+faculties = r"(?:[Mm]athematics|[Mm]athématiques|[Ss]cience)"
+credit_count = r"(?P<credit_count>\d+ crédits de cours(?: en)?(?: %s)? \(?(?:[A-Z]{3}\)?(?: ou [A-Z]{3})* de niveau \d000(?: ou supérieur)*|universitaire)|\d+(?: course)? units (?:of|in)(?: %s)? \(?(?:[A-Z]{3}\)?(?: or [A-Z]{3})*(?: courses)? at(?: the| level)? \d000(?: level)?(?: or above)?|university-level courses?))" % (faculties, faculties)
+for_special_program = r"(?P<for_special_program> or for honors %s students: | ou pour les étudiants et étudiantes inscrits aux programmes spécialisés en %s : )" % (faculties, faculties)
+parsable_codes = r"(?:\(*(?:%s)\)*(?:, |/| or | ou | and | et |%s)?)+" % (course_code_pattern + '|' + not_real_course_codes + '|(?:' + credit_count + ')', for_special_program)
+
+#common patterns
+code_re = re.compile(course_code_pattern)
+credit_re = re.compile(r"\([0-9]{1,} (unit[s]{0,1}|crédit[s]{0,1})\)|[0-9]{1,} (unit[s]{0,1}|crédit[s]{0,1})")
+subj_re = re.compile(r"\([A-Z]{3}\)")
+href_re = re.compile("[/]{0,1}en/courses/[A-Za-z]{1,}[/]{0,1}")
+numbers_re = re.compile('[0-9]{1,}')
+
+#prereq and other courseblockextras patterns
+prereq = {
+	"not_combined_for_credits" : re.compile(r"(?:(?<=^(?:(?:The )?[Cc]ourses |Les cours ))%s(?=(?: cannot be combined for (?:units|credits)$| ne peuvent être combinés pour l'obtention de crédits$))|(?<=This course cannot be taken for units by any student who has previously received units for )%s$)" % (parsable_codes, course_code_pattern)),
+	"no_credits_in_program" : re.compile(r"(?:This course cannot count for unit in any program in the Faculty of |Prerequisite: This course cannot count as a %s elective for students in the Faculty of |Ce cours ne peut pas compter pour fin de crédits dans un programme de la Faculté des |Préalable : Ce cours ne peut pas compter comme cours au choix en %s pour les étudiants et étudiantes de la Faculté des )%s" % (faculties, faculties, faculties)),
+	"prerequisites" : re.compile(r"(?<=^(?:/ )?(?:Prerequisite|Préalable)s?\s*:\s*(?:One of )?)%s$" % parsable_codes),
+	"corequisite" : re.compile(r"(?:Corequisite|Concomitant)\s*:\s*%s|%s(?= are prerequisite or corequisite to %s$)|(?<=Les cours )%s(?= sont préalables ou concomitants à %s$)" % (parsable_codes, parsable_codes, course_code_pattern, parsable_codes, course_code_pattern)),
+	"CGPA_requirements" : re.compile(r"(?:Prerequisite: The student must have a minimum CGPA of \d(?:\.|,)\d|Préalable : L'étudiant ou l'étudiante doit avoir conservé une MPC minimale de \d(?:\.|,)\d|Seulement disponible pour les étudiants ayant une MPC de \d,\d et plus)|Open only to students whose cumulative grade point average is \d\.\d or over(?: and the permission of the Department| et avoir la permission du Département)?(?:, and who have completed all the first(?: and second)? year [A-Z]{3} core courses of their program| et ayant réussi tous les cours [A-Z]{3} du tronc commun de niveaux 1000(?: et 2000)? de leur programme)?$"),
+	# "credit_count" : re.compile(r"Préalable ?: \d+ crédits de cours(?: en)?(?: %s)? \(?(?:[A-Z]{3}\)?(?: ou [A-Z]{3})* de niveau \d000(?: ou supérieur)*|universitaire)|Prerequisite: \d+(?: course)? units (?:of|in)(?: %s)? \(?(?:[A-Z]{3}\)?(?: or [A-Z]{3})*(?: courses)? at(?: the| level)? \d000(?: level)?(?: or above)?|university-level courses?)$" % (faculties, faculties)),
+	#TODO: do some testing to see if you still need this seperate or if it's ok only being part of the prerequisite pattern
+
+	"prior_knowledge" : re.compile(r"Prerequisites: familiarity with basic concepts in .*|(?:or )?A basic knowledge of .*$|Prerequisite: Some familiarity with .*"),
+	"additional_prereqs" : re.compile(r"Additional prerequisites may be imposed depending on the topic|Des préalables supplémentaires peuvent s'appliquer selon le sujet du cours"),
+	"permission" : re.compile(r"Permission of the Department is required$|Permission du Département est requise.?$"),	#TODO: This should be combined with "not_real_course_codes" or be moved here on it's own
+	"interview" : re.compile(r"Interview with Professor is required$|Entrevue avec le professeur est requise$"),
+
+	"also_offered_as" : re.compile(r"(?<=^(?:Also offered as |Aussi offert sous la cote ))%s$" % course_code_pattern),
+	"primarily_intended_for" : re.compile(r"[Tt]his course is .* for .*$|Ce cours .* principalement(?: destiné)? aux étudiants et étudiantes .*$"),
+	"previously" : re.compile(r"(?:Previously|Antérieurement) %s" % course_code_pattern),
+}

--- a/uO_scrape.py
+++ b/uO_scrape.py
@@ -5,6 +5,7 @@ import pandas as pd
 import json
 from time import sleep, perf_counter as pf
 import regex as re
+import itertools as it
 
 requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ':DES-CBC3-SHA'
 #timetable_url = 'https://web30.uottawa.ca/v3/SITS/timetable/Search.aspx'
@@ -137,7 +138,8 @@ def get_courses(link):
 		comp = comp.split(':', 1)[-1].strip()
 		comp = [x.strip() for x in comp.split('/')[-1].split(',')]
 		#getting the prerequisites from after the colon in the sentence
-		pre, dep = parse_prereqs(pre)
+		pre = Prereq(pre)
+		dep = None
 		# pre = pre.split(':', 1)[-1].strip()
 		# #extracting dependencies from the prerequisite list
 		# dep = extract_codes('.'.join([x for x in pre.split('.') if ('cannot' not in x) and ('Must' not in x)]))
@@ -145,18 +147,24 @@ def get_courses(link):
 		courses.append([code, title, credits, desc, comp, pre, dep])
 	return pd.DataFrame(courses, columns = ['code', 'title', 'credits', 'desc', 'components', 'prerequisites', 'dependencies'])
 
-def compile_prereq_patterns():
+class Prereq:
+	'''
+	Object used to hold information about prereqs and other information that is provided in the courseblockextra section of the uOttawa catalogue
+	'''
 	course_code_pattern = r"[A-Z]{3}\s*[0-9]{4,5}[A-Za-z]{0,1}"
 	not_real_course_codes = r".*[34]U.*|(?:an )?equivalent|Permission of the School|Permission de l'École|Permission de l'Institut|Approval of the instructor"
-	parsable_codes = r"(?:\(?(?:%s)\)?(?:, | or | ou )?)+" % course_code_pattern + '|' + not_real_course_codes
 	faculties = r"(?:[Mm]athematics|[Mm]athématiques|[Ss]cience)"
+	credit_count = r"\d+ crédits de cours(?: en)?(?: %s)? \(?(?:[A-Z]{3}\)?(?: ou [A-Z]{3})* de niveau \d000(?: ou supérieur)*|universitaire)|\d+(?: course)? units (?:of|in)(?: %s)? \(?(?:[A-Z]{3}\)?(?: or [A-Z]{3})*(?: courses)? at(?: the| level)? \d000(?: level)?(?: or above)?|university-level courses?)" % (faculties, faculties)
+	parsable_codes = r"(?:\(*(?:%s)\)*(?:, |/| or | ou | and | et | or for honors %s students: | ou pour les étudiants et étudiantes inscrits aux programmes spécialisés en %s : )?)+" % (course_code_pattern + '|' + not_real_course_codes + '|(?:' + credit_count + ')', faculties, faculties)
 
-	return {
-		"not_combined_for_credits" : re.compile(r"(?:(?<=^(?:(?:The )?[Cc]ourses |Les cours ))%s(?=(?: cannot be combined for units$| ne peuvent être combinés pour l'obtention de crédits$))|(?<=This course cannot be taken for units by any student who has previously received units for )%s$)|(?:This course cannot count for unit in any program in the Faculty of |Prerequisite: This course cannot count as a science elective for students in the Faculty of |Ce cours ne peut pas compter pour fin de crédits dans un programme de la Faculté des |Préalable : Ce cours ne peut pas compter comme cours au choix en sciences pour les étudiants et étudiantes de la Faculté des )%s" % (parsable_codes, course_code_pattern, faculties)),
-		"prerequisites" : re.compile(r"(?<=^(?:Prerequisite|Préalable)s?\s*:\s*)(?:One of )?%s$" % parsable_codes),
-		"corequisite" : re.compile(r"%s(?= are prerequisite or corequisite to %s$)" % (parsable_codes, course_code_pattern)),
+	patterns = {
+		"not_combined_for_credits" : re.compile(r"(?:(?<=^(?:(?:The )?[Cc]ourses |Les cours ))%s(?=(?: cannot be combined for units$| ne peuvent être combinés pour l'obtention de crédits$))|(?<=This course cannot be taken for units by any student who has previously received units for )%s$)" % (parsable_codes, course_code_pattern)),
+		"no_credits_in_program" : re.compile(r"(?:This course cannot count for unit in any program in the Faculty of |Prerequisite: This course cannot count as a %s elective for students in the Faculty of |Ce cours ne peut pas compter pour fin de crédits dans un programme de la Faculté des |Préalable : Ce cours ne peut pas compter comme cours au choix en %s pour les étudiants et étudiantes de la Faculté des )%s" % (faculties, faculties, faculties)),
+		"prerequisites" : re.compile(r"(?<=^(?:/ )?(?:Prerequisite|Préalable)s?\s*:\s*(?:One of )?)%s$" % parsable_codes),
+		"corequisite" : re.compile(r"(?:Corequisite|Concomitant)\s*:\s*%s|%s(?= are prerequisite or corequisite to %s$)|(?<=Les cours )%s(?= sont préalables ou concomitants à %s$)" % (parsable_codes, parsable_codes, course_code_pattern, parsable_codes, course_code_pattern)),
 		"CGPA_requirements" : re.compile(r"(?:Prerequisite: The student must have a minimum CGPA of \d(?:\.|,)\d|Préalable : L'étudiant ou l'étudiante doit avoir conservé une MPC minimale de \d(?:\.|,)\d|Seulement disponible pour les étudiants ayant une MPC de \d,\d et plus)|Open only to students whose cumulative grade point average is \d\.\d or over(?: and the permission of the Department| et avoir la permission du Département)?(?:, and who have completed all the first(?: and second)? year [A-Z]{3} core courses of their program| et ayant réussi tous les cours [A-Z]{3} du tronc commun de niveaux 1000(?: et 2000)? de leur programme)?$"),
-		"credit_Count" : re.compile(r"Préalable ?: \d+ crédits de cours(?: en)?(?: %s)? \(?(?:[A-Z]{3}\)?(?: ou [A-Z]{3})* de niveau \d000(?: ou supérieur)*|universitaire)|Prerequisite: \d+(?: course)? units (?:of|in)(?: %s)? \(?(?:[A-Z]{3}\)?(?: or [A-Z]{3})*(?: courses)? at(?: the| level)? \d000(?: level)?(?: or above)?|university-level courses?)$" % (faculties, faculties)),
+		# "credit_count" : re.compile(r"Préalable ?: \d+ crédits de cours(?: en)?(?: %s)? \(?(?:[A-Z]{3}\)?(?: ou [A-Z]{3})* de niveau \d000(?: ou supérieur)*|universitaire)|Prerequisite: \d+(?: course)? units (?:of|in)(?: %s)? \(?(?:[A-Z]{3}\)?(?: or [A-Z]{3})*(?: courses)? at(?: the| level)? \d000(?: level)?(?: or above)?|university-level courses?)$" % (faculties, faculties)),
+		#TODO: do some testing to see if you still need this seperate or if it's ok only being part of the prerequisite pattern
 
 		"prior_knowledge" : re.compile(r"Prerequisites: familiarity with basic concepts in .*|(?:or )?A basic knowledge of .*$|Prerequisite: Some familiarity with .*"),
 		"additional_prereqs" : re.compile(r"Additional prerequisites may be imposed depending on the topic|Des préalables supplémentaires peuvent s'appliquer selon le sujet du cours"),
@@ -168,21 +176,79 @@ def compile_prereq_patterns():
 		"previously" : re.compile(r"(?:Previously|Antérieurement) %s" % course_code_pattern),
 	}
 
+	def parse_codes(parsable):
+		'''
+		Truns a string of parsable codes into a list of prerequiste groups that are each sufficient to get into the course
+		A string of parsable codes is defined as any string of courses codes seperated by any of [/ or ou , and et] and parentheses for priotirty.
+		'''
 
-#TODO: this is a terrible place to have this
-prereq_patterns = compile_prereq_patterns()
+		parsable = parsable.replace(" ou ", " or ").replace("/", " or ").replace(" and ", ", ").replace(" et ", ", ")
 
-def parse_prereqs(prereqStr):
-
-	sentences = prereqStr.split('. ')
-	for sentence in sentences:
-		for pattern in prereq_patterns.values():
-			if pattern.search(sentence):
+		#Replace all parenthesised groups with a unique fake course code
+		replacement_codes = ("XXX%04d" % i for i in it.count())
+		codes = []
+		for code in replacement_codes:
+			pos = -1
+			for i, c in enumerate(parsable):
+				if c == '(':
+					pos = i
+				elif c == ')':
+					codes.append((code, parsable[pos+1:i]))
+					parsable = parsable[:pos] + code + parsable[i+1:]
+					break	#This increments to the next replacement code and starts from the beginning of the string
+			else:	#When we reach the end of the string we're done
 				break
-		else:
-			print(sentence)
 
-	return None, None
+		#Replace " or " groups with fake course codes as well
+		parsable = parsable.split(', ')
+		for i, item in enumerate(parsable):
+			if " or " in item:
+				code = next(replacement_codes)
+				codes.append((code, item))
+				parsable[i] = code
+
+		prereq_groups = [parsable]
+
+		#Sub fake codes back in for a list of possible prereq groups
+		for code, replacement in reversed(codes):
+			print(prereq_groups)
+			while True:	#This is to overcome the problem with modifying a list as you iterate over it, kind of a hack but it works
+				for group in prereq_groups:
+					if code in group:
+						if ", " in replacement:
+							group.remove(code)
+							group += replacement.split(", ")
+						elif " or " in replacement:
+							prereq_groups.remove(group)
+							group.remove(code)
+							for c in replacement.split(" or "):
+								prereq_groups.append(group + [c])
+							break
+				else:
+					break
+
+		return prereq_groups
+
+
+	parsers = {
+		"prerequisites" : parse_codes
+	}
+
+	def __init__(self, prereqStr):
+
+		sentences = filter(None, prereqStr.replace(' / ', '. ').split('. '))
+		for sentence in sentences:
+			for key, pattern in self.patterns.items():
+				match = pattern.search(sentence)
+				if match:
+					break
+					# print(key)
+					# print(match.group())
+					# print(match.string)
+					# print()
+			else:
+				# pass
+				print(sentence)
 
 
 def get_course_tables(links):


### PR DESCRIPTION
So the basic idea of this was pretty simple: get prereqs working in a way that was machine readable. Basically what that lead to was a list of lists of possible sufficient groups of courses i.e.
> Prerequisites: MAT 1348, (CSI 3120 or SEG 2106).

should become
```python
[[MAT 1348, CSI 3120],
[MAT 1348, SEG 2106]]
```
In this PR there's a lot of code that's not necessary for that specific purpose, but was built up as part of the larger framework to support parsing information about all values in the "extras" section of the courses blocks. Future usage includes: corequisites, courses that cannot be combined for credits, CGPA requirements for taking a course, as well as other requirements that can be specified such as an interview with the prof or prior knowledge on a topic.

To use the `Prereq` class that this PR adds, simply create a instance of it passing the string containing the prerequisites it should contain. Then the list of prereqs will be available in the `prereqs` attribute of the class. Future iterations of the class will likely have better apis to retrieve information, but for the moment this seemed sufficient given that there was only one type of information being parsed.

Note: the `itertools` package and the `regex` package are now dependencies for this tool, unfortunately python's default regex package `re` didn't support some of the more complicated regex expressions required for this functionality.