### PR TITLE
Feature/expose available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/*/uoapi.py
 *.vscode
 *.vscode/*
 *.egg*
+tags

--- a/tests/timetable/test_query_timetable.py
+++ b/tests/timetable/test_query_timetable.py
@@ -6,6 +6,7 @@ import regex as re
 from httmock import urlmatch, HTTMock
 
 import uoapi.timetable.query_timetable as qt
+from uoapi.timetable import available
 
 #@TODO Test accented characters on various systems
 # e.g. accented characters/encoding caused tests to
@@ -273,6 +274,19 @@ class TestTimetableQuery(unittest.TestCase):
                 )
             self.assertNotIn("UO_PUB_SRCH_WRK_GRADUATED_TBL_CD$chk$0", self.tq.form)
             self.assertNotIn("UO_PUB_SRCH_WRK_GRADUATED_TBL_CD$0", self.tq.form)
+
+    def test_available_terms(self):
+        self.mock_server.status_code = 200
+        self.mock_server.swap_responses("GET", "good")
+        with HTTMock(self.mock_server.http_response):
+            self.assertEqual(
+                available()["available"],
+                [{
+                    "year": 2020,
+                    "term": "winter",
+                }]
+            )
+
 
     def test_call(self):
         with self.subTest("bad input"):

--- a/uoapi/__version__.py
+++ b/uoapi/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0dev12"
+__version__ = "1.0.0dev13"

--- a/uoapi/timetable/__init__.py
+++ b/uoapi/timetable/__init__.py
@@ -1,5 +1,11 @@
 
 from uoapi.timetable import query_timetable
-from uoapi.timetable.cli import (parser, cli, available, main as py_cli,
-    help as cli_help, description as cli_description, epilog as cli_epilog
+from uoapi.timetable.cli import (
+    parser,
+    cli,
+    available,
+    main as py_cli,
+    help as cli_help,
+    description as cli_description,
+    epilog as cli_epilog,
 )

--- a/uoapi/timetable/__init__.py
+++ b/uoapi/timetable/__init__.py
@@ -1,5 +1,5 @@
 
 from uoapi.timetable import query_timetable
-from uoapi.timetable.cli import (parser, cli, main as py_cli, 
+from uoapi.timetable.cli import (parser, cli, available, main as py_cli,
     help as cli_help, description as cli_description, epilog as cli_epilog
 )

--- a/uoapi/timetable/cli.py
+++ b/uoapi/timetable/cli.py
@@ -123,15 +123,24 @@ def cli(args=None):
             print(json.dumps(out))
 
 def available(retries=2):
-    tq = qt.TimetableQuery(retries=retries)
-    with tq as gm:
-        out = {"available": [
-            at
-            for at in map(qt.parse_available, tq.available.keys())
-            if at is not None
-        ]}
-    out["messages"] = gm
-    return out
+    try:
+        tq = qt.TimetableQuery(retries=retries)
+        with tq as gm:
+            out = {"available": [
+                at
+                for at in map(qt.parse_available, tq.available.keys())
+                if at is not None
+            ]}
+        out["messages"] = gm
+        return out
+    except Exception as e:
+        return {
+            "available": [],
+            "messages": [{
+                "type": "error",
+                "message": "Unknown failure: {} = {}".format(type(e), e),
+            }],
+        }
 
 def main(courses, year, term, saveraw=None, refresh=5, retries=2, waittime=2):
     if saveraw is not None and os.path.isdir(saveraw):

--- a/uoapi/timetable/cli.py
+++ b/uoapi/timetable/cli.py
@@ -122,10 +122,14 @@ def cli(args=None):
         ):
             print(json.dumps(out))
 
-def available(retries):
+def available(retries=2):
     tq = qt.TimetableQuery(retries=retries)
     with tq as gm:
-        out = {"available": list(tq.available.values())}
+        out = {"available": [
+            at
+            for at in map(qt.parse_available, tq.available.keys())
+            if at is not None
+        ]}
     out["messages"] = gm
     return out
 

--- a/uoapi/timetable/cli.py
+++ b/uoapi/timetable/cli.py
@@ -127,9 +127,12 @@ def available(retries=2):
         tq = qt.TimetableQuery(retries=retries)
         with tq as gm:
             out = {"available": [
-                at
-                for at in map(qt.parse_available, tq.available.keys())
-                if at is not None
+                available_terms
+                # Map the function which parses uOttawa term codes
+                # across the sequence of codes (the keys in `tq.available`).
+                for available_terms in map(qt.parse_available, tq.available.keys())
+                # Filter out the codes which failed to parse.
+                if available_terms is not None
             ]}
         out["messages"] = gm
         return out

--- a/uoapi/timetable/query_timetable.py
+++ b/uoapi/timetable/query_timetable.py
@@ -497,20 +497,23 @@ def normalize_whitespace(string):
 
 # Scraping
 
+def _fail_value(fail, message):
+    if fail:
+        raise ValueError(message)
+
 def parse_available(s):
     s = s.strip().lower()
-    assert len(s) == 4
+    _fail_value(len(s) != 4, "The term code should be 4 digits long")
     s = s[1:]
     try:
         year = "20" + s[:2]
-        assert len(year) == 4
+        _fail_value(len(year) != 4, "The year should have 4 digits")
         return {
             "year": int(year),
             "term": num_to_term[s[2:]],
         }
     except Exception:
         return None
-
 
 def extract_section(section, descr, log=False, err_msg_prefix=""):
     em = ErrorMessenger(log=log, prefix=err_msg_prefix)

--- a/uoapi/timetable/query_timetable.py
+++ b/uoapi/timetable/query_timetable.py
@@ -38,8 +38,13 @@ term_to_num = (
     ("winter","1"),
     ("9", "9"),
     ("5", "5"),
-    ("1","1"),
+    ("1", "1"),
 )
+num_to_term = dict((
+    ("9", "fall"),
+    ("5", "summer"),
+    ("1", "winter"),
+))
 default_headers = (('Content-Type', "application/x-www-form-urlencoded"),)
 
 # Utilities
@@ -491,6 +496,21 @@ def normalize_whitespace(string):
     return string.strip()
 
 # Scraping
+
+def parse_available(s):
+    s = s.strip().lower()
+    assert len(s) == 4
+    s = s[1:]
+    try:
+        year = "20" + s[:2]
+        assert len(year) == 4
+        return {
+            "year": int(year),
+            "term": num_to_term[s[2:]],
+        }
+    except Exception:
+        return None
+
 
 def extract_section(section, descr, log=False, err_msg_prefix=""):
     em = ErrorMessenger(log=log, prefix=err_msg_prefix)


### PR DESCRIPTION
This adds a simple parser for uOttawa year-term codes, and exposes that previously "private" method.

I'm not sure if github can automatically create a tag with the version once this is merged, but if not we'll need to to that so it can be used in uSchedule.